### PR TITLE
Default to wayland and fallback to x11 if needed

### DIFF
--- a/io.github.everestapi.Olympus.yml
+++ b/io.github.everestapi.Olympus.yml
@@ -5,7 +5,8 @@ sdk: org.freedesktop.Sdk
 command: olympus
 finish-args:
   # Allow the GUI to render
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   # Needed to access mod list and download mods
   - --share=network


### PR DESCRIPTION
This PR makes Olympus default to Wayland if it's available.